### PR TITLE
fixed bug that would edit timezone when not needed

### DIFF
--- a/inkycal/modules/ical_parser.py
+++ b/inkycal/modules/ical_parser.py
@@ -124,23 +124,37 @@ class iCalendar:
                         t_start_recurring, t_end_recurring)
                         for ical in self.icalendars)
 
-    events = (
-      {
-      'title': events.get('SUMMARY').lstrip(),
+    event_list = []
+    for ical in recurring_events:
+        for events in ical:
+            this_event = {}
+            this_event['title'] = events.get('SUMMARY').lstrip()
+            
+            starts_and_ends_at_midnight = False
+            ends_on_a_later_day_than_it_started = False
+            
+            if arrow.get(events.get('dtstart').dt).format('HH:mm') and arrow.get(events.get('dtend').dt).format('HH:mm') == '00:00':
+                starts_and_ends_at_midnight = True
+                
+            if int(arrow.get(events.get('dtstart').dt).format('DDD')) < int(arrow.get(events.get('dtend').dt).format('DDD')):
+                ends_on_a_later_day_than_it_started = True
 
-      'begin': arrow.get(events.get('DTSTART').dt).to(timezone) if (
-        arrow.get(events.get('dtstart').dt).format('HH:mm') != '00:00')
-        else arrow.get(events.get('DTSTART').dt).replace(tzinfo=timezone),
+            if int(arrow.get(events.get('dtstart').dt).format('DDD')) == 365 and int(arrow.get(events.get('dtend').dt).format('DDD')) < 365:
+                ends_on_a_later_day_than_it_started = True
+                
+            if starts_and_ends_at_midnight == True and ends_on_a_later_day_than_it_started == True:
+                # this is most likely an all-day event and we need to add timezone info to it
+                this_event['begin'] = arrow.get(events.get('DTSTART').dt).replace(tzinfo=timezone)
+                this_event['end'] = arrow.get(events.get('DTEND').dt).replace(tzinfo=timezone)
+            else:
+                # this is probably not an all-day event
+                # this might be a regular old event, or an event that starts at midnight UTC but doesn't end at midnight UTC
+                this_event['begin'] = arrow.get(events.get('DTSTART').dt).to(timezone)
+                this_event['end'] = arrow.get(events.get('DTEND').dt).to(timezone)
+            
+            event_list.append(this_event)
 
-      'end':arrow.get(events.get("DTEND").dt).to(timezone) if (
-        arrow.get(events.get('dtstart').dt).format('HH:mm') != '00:00')
-        else arrow.get(events.get('DTEND').dt).replace(tzinfo=timezone)
-
-      } for ical in recurring_events for events in ical)
-
-
-    # if any recurring events were found, add them to parsed_events
-    if events: self.parsed_events += list(events)
+    if events: self.parsed_events += list(event_list)
 
     # Sort events by their beginning date
     self.sort()
@@ -191,7 +205,7 @@ class iCalendar:
       local_tz = None
     return local_tz
 
-  def show_events(self, fmt='DD MMM YY HH:mm'):
+  def show_events(self, fmt='DD MMM YY HH:mm Z'):
     """print all parsed events in a more readable way
     use the format (fmt) parameter to specify the date format
     see https://arrow.readthedocs.io/en/latest/#supported-tokens


### PR DESCRIPTION
As background: iCal doesn't give you any info about whether an event is an all-day event and it also doesn't include timezone info, which is different than all other events. It's important to know which events are all-day and which are not, because all-day events are not converted to local time, instead the local time tag is only added so it shows up in the proper order. 

This fix addresses the following bug: Previously, when an event started at 0000 UTC, inkycal would assume it was an all-day event. So, other events that started at 0000 UTC (which, for me, is 7 pm EST) would be handled in the same way as all-day events and they would not be converted to local time. So that meant all my 1900 EST events would show up as starting at 0000 EST. I added code that attempts to further clarify what an all-day event is and ensure that regular events starting at 0000 UTC are properly converted to local time.

Now an event that is all day must be both of the following:

1. Start _and_ end at 0000 UTC
2. End on a day that is later than the day it started

Unfortunately, the code is not nearly as clean and beautiful as the code that ace wrote. I attempted to write is as clear as possible, so that future people will be able to understand it. This update is critical for those in timezones who frequently have events that start at 0000 UTC.